### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/ion_req.dart
+++ b/lib/src/ion_req.dart
@@ -20,7 +20,7 @@ class IonRequest {
   }
 
   init() async {
-    post = await original.transform(Utf8Decoder()).join();
+    post = await original.cast<List<int>>().transform(Utf8Decoder()).join();
     print(post);
     body = Uri(query: post).queryParameters;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,6 @@ name: ion
 author: Paweł Perek <pawelperek99@gmail.com>
 description: A HTTP framework highly influenced by Express in which you easy and fast make a server without writing a lot of code
 homepage: https://github.com/drPeru/Ion
-version: 0.4.4
+version: 0.4.4+1
 environment:
   sdk: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900